### PR TITLE
Always invoke PlantUML with UTF-8 charset

### DIFF
--- a/plantuml-filter.js
+++ b/plantuml-filter.js
@@ -19,7 +19,7 @@ function filterPlantuml(type, value, format, meta) {
     var umlText = value[1];
 
     var plantumlPath = path.join(__dirname, "plantuml.8036.jar");
-    var res = execSync(util.format("java -jar \"%s\" -charset UTF-8 -pipe", plantumlPath), { input: umlText });
+    var res = execSync(util.format("java -splash:no -jar \"%s\" -charset UTF-8 -pipe", plantumlPath), { input: umlText });
     var tempDirName = ".temp";
     if (!fs.existsSync(tempDirName)) {
         fs.mkdirSync(tempDirName);

--- a/plantuml-filter.js
+++ b/plantuml-filter.js
@@ -19,7 +19,7 @@ function filterPlantuml(type, value, format, meta) {
     var umlText = value[1];
 
     var plantumlPath = path.join(__dirname, "plantuml.8036.jar");
-    var res = execSync(util.format("java -jar \"%s\" -pipe", plantumlPath), { input: umlText });
+    var res = execSync(util.format("java -jar \"%s\" -charset UTF-8 -pipe", plantumlPath), { input: umlText });
     var tempDirName = ".temp";
     if (!fs.existsSync(tempDirName)) {
         fs.mkdirSync(tempDirName);

--- a/plantuml-filter.js
+++ b/plantuml-filter.js
@@ -25,7 +25,7 @@ function filterPlantuml(type, value, format, meta) {
         fs.mkdirSync(tempDirName);
     }
 
-    var fileName = util.format("%d.png", imgCounter);
+    var fileName = util.format("%d.png", imgCounter++);
     var filePath = path.join(tempDirName, fileName);
     fs.writeFileSync(filePath, res);
 


### PR DESCRIPTION
The default charset used when reading the text files containing the UML
text description is system dependent.
Pandoc uses the UTF-8 character encoding for both input and output.